### PR TITLE
Add scripts to build and search FAISS index

### DIFF
--- a/build_index.py
+++ b/build_index.py
@@ -1,0 +1,59 @@
+import os
+import json
+from pathlib import Path
+
+import faiss
+from langchain.document_loaders import PyPDFLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from sentence_transformers import SentenceTransformer
+
+
+def collect_chunks(users_dir: Path):
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    metadata = []
+    texts = []
+
+    for user_dir in users_dir.iterdir():
+        if not user_dir.is_dir():
+            continue
+        for pdf_path in user_dir.glob("*.pdf"):
+            loader = PyPDFLoader(str(pdf_path))
+            pages = loader.load()
+            docs = text_splitter.split_documents(pages)
+            for idx, doc in enumerate(docs):
+                text = doc.page_content
+                texts.append(text)
+                metadata.append({
+                    "user": user_dir.name,
+                    "file": pdf_path.name,
+                    "chunk_id": idx,
+                    "chunk": text,
+                })
+    return texts, metadata
+
+
+def build_index(texts):
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    embeddings = model.encode(texts, show_progress_bar=True)
+    embeddings = embeddings.astype("float32")
+
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(embeddings)
+    return index
+
+
+def main():
+    users_dir = Path("users")
+    index_path = Path("index.faiss")
+    meta_path = Path("index_meta.json")
+
+    texts, metadata = collect_chunks(users_dir)
+    index = build_index(texts)
+
+    faiss.write_index(index, str(index_path))
+    with meta_path.open("w") as f:
+        json.dump(metadata, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/search.py
+++ b/search.py
@@ -1,0 +1,43 @@
+import json
+import sys
+from pathlib import Path
+
+import faiss
+from sentence_transformers import SentenceTransformer
+import numpy as np
+
+
+INDEX_FILE = Path("index.faiss")
+META_FILE = Path("index_meta.json")
+
+
+def load_resources():
+    index = faiss.read_index(str(INDEX_FILE))
+    with META_FILE.open() as f:
+        metadata = json.load(f)
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    return index, metadata, model
+
+
+def search(query: str, k: int = 5):
+    index, metadata, model = load_resources()
+    emb = model.encode([query]).astype("float32")
+    distances, ids = index.search(emb, k)
+
+    for dist, idx in zip(distances[0], ids[0]):
+        info = metadata[idx]
+        print(f"File: {info['user']}/{info['file']} - Chunk {info['chunk_id']} (score: {dist:.4f})")
+        print(info['chunk'])
+        print("-" * 40)
+
+
+def main():
+    if len(sys.argv) > 1:
+        query = " ".join(sys.argv[1:])
+    else:
+        query = input("Enter query: ")
+    search(query)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `build_index.py` to generate FAISS index from user PDFs
- add `search.py` to query the built index

## Testing
- `python3 -m py_compile build_index.py`
- `python3 -m py_compile search.py`


------
https://chatgpt.com/codex/tasks/task_b_683f27bdba70832fb3fa7bee90e7d742